### PR TITLE
fix crash when pressing tab on the last tag in the tags list

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -1,2 +1,2 @@
 @echo off
-odin.exe build src -out:target/todool.exe -thread-count:12 && pushd target && todool.exe && popd
+odin.exe build src -out:target/todool.exe -thread-count:12 -subsystem:windows && pushd target && todool.exe && popd

--- a/src/global.odin
+++ b/src/global.odin
@@ -903,6 +903,9 @@ window_input_event :: proc(window: ^Window, msg: Message, di: int = 0, dp: rawpt
 								if sibling != nil {
 									element = sibling
 									break
+								} else {
+									element = &window.element
+									break next_search
 								}
 
 								if window.dialog == nil {


### PR DESCRIPTION
In the Tags panel, you can press Tab to select the next tag.
When you pressed Tab while selecting the last tag in the list, the program went into an infinite loop, unable to find the next tag, and crashed.
This appears to fix the issue.
