### PR TITLE
Fix for compatibility with Odin 2024-04

### DIFF
--- a/src/global.odin
+++ b/src/global.odin
@@ -264,7 +264,7 @@ image_path :: proc(img: ^Stored_Image) -> string {
 image_find :: proc(path: string) -> (index: int) {
 	index = -1
 	
-	for img, i in &gs.stored_images {
+	for &img, i in &gs.stored_images {
 		if image_path(&img) == path {
 			index = i
 			return 
@@ -323,7 +323,7 @@ image_load_from_file :: proc(path: string) -> (res: ^image.Image) {
 // loads images on a seperate thread to the stored data
 image_load_process_on_thread :: proc() {
 	{
-		for img in &gs.stored_images {
+		for &img in &gs.stored_images {
 			// loading needs to be done
 			if !img.loaded {
 				img.backing = image_load_from_file(image_path(&img))

--- a/src/keymap.odin
+++ b/src/keymap.odin
@@ -170,7 +170,7 @@ keymap_command_find_combo :: proc(
 	du: u32 = COMBO_EMPTY,
 ) -> (res: ^Combo_Node) {
 	if command_index != -1 {
-		for node in &keymap.combos {
+		for &node in &keymap.combos {
 			if command_index == node.command_index && node.du == du {
 				res = &node
 				return
@@ -209,7 +209,7 @@ keymap_combo_execute :: proc(keymap: ^Keymap, combo: string) -> bool {
 	// }
 
 	// lookup linear
-	for node in &keymap.combos {
+	for &node in &keymap.combos {
 		if cmd, ok := keymap_combo_match(keymap, &node, combo); ok {
 			cmd(node.du)
 			return true

--- a/src/keymap_editor.odin
+++ b/src/keymap_editor.odin
@@ -267,7 +267,7 @@ keymap_editor_check_conflict_removal :: proc(keymap: ^Keymap, combo_node: ^Combo
 		// count and keep track of existing conflicts
 		temp := make([dynamic]^Combo_Node, 0, 32, context.temp_allocator)
 		count: int
-		for node in &keymap.combos {
+		for &node in &keymap.combos {
 			if node.conflict == conflict_check {
 				count += 1
 				append(&temp, &node)
@@ -307,7 +307,7 @@ keymap_editor_check_conflicts :: proc(keymap: ^Keymap, skip: ^Combo_Node, check:
 
 	// hook up nodes that dont have a conflict set yet
 	conflict: ^Combo_Conflict
-	for node in &keymap.combos {
+	for &node in &keymap.combos {
 		c1 := string(node.combo[:node.combo_index])
 
 		if &node != skip && node.conflict == nil && c1 == check {
@@ -699,7 +699,7 @@ keymap_editor_push_keymap :: proc(keymap: ^Keymap, header: string, folded: bool)
 	}
 
 	line_count: int
-	for node in &keymap.combos {
+	for &node in &keymap.combos {
 		keymap_editor_line_append(grid, &node, line_count)
 		line_count += 1
 	}

--- a/src/main.odin
+++ b/src/main.odin
@@ -241,7 +241,7 @@ main_update :: proc(window: ^Window) {
 	statusbar_update(&statusbar)
 	power_mode_set_caret_color()
 
-	for cam in &app.mmpp.cam {
+	for &cam in &app.mmpp.cam {
 		cam_update_check(&cam)
 	}
 

--- a/src/renderer.odin
+++ b/src/renderer.odin
@@ -226,7 +226,7 @@ render_target_destroy :: proc(using target: ^Render_Target) {
 	delete(vertices)
 	delete(groups)
 	
-	for texture in &textures {
+	for &texture in &textures {
 		texture_destroy(&texture)
 	}
 

--- a/src/save.odin
+++ b/src/save.odin
@@ -415,7 +415,7 @@ save_all :: proc(file_path: string) -> (err: Save_Error) {
 
 		// gather all removed lines in a non duplicate map
 		list := make(map[int]Empty, 256, context.temp_allocator)
-		for task, list_index in &app.pool.list {
+		for &task, list_index in &app.pool.list {
 			if task.removed {
 				set(&list, &task, list_index)
 			}

--- a/src/theme.odin
+++ b/src/theme.odin
@@ -803,7 +803,7 @@ theme_editor_menu_colors :: proc() {
 	p := menu.panel
 	p.shadow = true
 	
-	for preset in &theme_presets {
+	for &preset in &theme_presets {
 		theme_button_init(p, { .HF }, &preset)
 	}	
 }


### PR DESCRIPTION
Looks like the newer Odin compiler ([dev-2024-04](https://github.com/odin-lang/Odin/releases/tag/dev-2024-04)) introduces some breaking changes.

These are the changes I had to make to try Todool myself.

They are all related to a change in the semantics of the iteration variable in for-in (at least when you eventually want to take its address).